### PR TITLE
Fix-release-on-tag

### DIFF
--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -27,8 +27,6 @@ jobs:
           name: P_COLLECTION_FILE_NAME
           value: ${{ steps.package.outputs.name }}-v${{ steps.package.outputs.version }}-postman-collection.json
 
-      - run: 'npx openapi-to-postmanv2 -s openapi3.yaml -o ${{ env.P_COLLECTION_FILE_NAME }}'
-
       - name: Publish Release to Github
         uses: softprops/action-gh-release@v1
         with:

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,3 +1,4 @@
+import config from 'config';
 import { readPackageJsonSync } from '@map-colonies/read-pkg';
 
 export const SERVICE_NAME = readPackageJsonSync().name ?? 'unknown_service';
@@ -6,7 +7,7 @@ export const DEFAULT_SERVER_PORT = 80;
 export const IGNORED_OUTGOING_TRACE_ROUTES = [/^.*\/v1\/metrics.*$/];
 export const IGNORED_INCOMING_TRACE_ROUTES = [/^.*\/docs.*$/];
 
-export const JOB_TYPE = 'ingestion';
+export const JOB_TYPE = config.get<string>('jobManager.jobType');
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const SERVICES: Record<string, symbol> = {


### PR DESCRIPTION
1. I removed the openapi check in the workflow: "release-on-tag-push" because there is no openapi.
2. I added changelog for workflow: ""release-on-tag-push"

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                      |